### PR TITLE
log consumed capacity if set

### DIFF
--- a/tests/test_project/settings.py
+++ b/tests/test_project/settings.py
@@ -132,6 +132,11 @@ PYDJAMODB_DATABASE = {
     'TAGS': {
         'Project': 'pydjamodb',
         'Name': '{table_name}',
+    },
+    'LOGGING': {
+        'pydjamodbtest': {
+            'RETURN_CONSUMED_CAPACITY': 'INDEXES'
+        }
     }
 }
 


### PR DESCRIPTION
the logged extra_data looks like this:
```
{
    'consumed_capacity': [{
        'TableName': 'mallpay-be-local-eventlog',
        'CapacityUnits': 6.0,
        'Table': {
            'CapacityUnits': 2.0
        },
        'GlobalSecondaryIndexes': {
            'related_objects_slug_triggered_at_index': {
                'CapacityUnits': 2.0
            },
            'related_object_triggered_at_index': {
                'CapacityUnits': 2.0
            }
        }
    }],
    'updated_columns': [{
        'related_object': 'eventlog-90f753ae-77fc-4fc0-a32a-e9d234b6ab0f',
        'slug': 'customer'
    }, {
        'related_object': 'customers-customer-9',
        'slug': 'customer'
    }]
}
```
settings then looks like (configurable for each table):
```
PYDJAMODB_DATABASE = {
    ...
    'LOGGING': {
        'eventlog': {
            'RETURN_CONSUMED_CAPACITY': 'INDEXES',
            'COLUMNS': {'slug', 'related_object'},
        },
        'reversion': {
            'RETURN_CONSUMED_CAPACITY': 'NONE',
        },
    }
}
```